### PR TITLE
fix bug of image url not correctly handled resulting imgage not display

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path')
 const PORT = process.env.PORT || 8080;
 // BASE_URL was necessary in my environment because Express app being served from another computer, not localhost
-const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`
+const BASE_URL = process.env.BASE_URL || `http://localhost:`
 
 
 const getAllVideosWithoutComments = () => {
@@ -16,8 +16,9 @@ const getAllVideosWithoutComments = () => {
 
 const getVideoInfo = (id) => {
     const matchingVideo = videosData.find(video => video.id === id)
-    matchingVideo.image = `${BASE_URL}:${PORT}${matchingVideo.image}`
-    return matchingVideo;
+    const matchingVideoCopy = JSON.parse(JSON.stringify(matchingVideo))
+    matchingVideoCopy.image = `${BASE_URL}:${PORT}${matchingVideo.image}`
+    return matchingVideoCopy;
 }
 
 const uploadVideo = (videoData) => {


### PR DESCRIPTION
- image urls in data file don't contain base_url, which will be added dynamically during runtim
- /videos/:id route handler had a bug that added base_url to current video's imgage url after each time current video changed, even  
- Bug caused by making change to properties of object referrece to data array
- Solution: make a deep copy of data and add base_url to to image url